### PR TITLE
Feature: Expose Palette.Swatch instead of Color for filtering dominant color

### DIFF
--- a/androidx-palette/src/androidInstrumentedTest/kotlin/androidx/palette/graphics/MaxColorsTest.kt
+++ b/androidx-palette/src/androidInstrumentedTest/kotlin/androidx/palette/graphics/MaxColorsTest.kt
@@ -17,9 +17,9 @@
 
 package androidx.palette.graphics
 
+import androidx.palette.graphics.TestUtils.loadSampleBitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
-import androidx.palette.graphics.TestUtils.loadSampleBitmap
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert

--- a/androidx-palette/src/commonTest/kotlin/com/kmpalette/palette/internal/utils/ColorUtilsTest.kt
+++ b/androidx-palette/src/commonTest/kotlin/com/kmpalette/palette/internal/utils/ColorUtilsTest.kt
@@ -1,6 +1,5 @@
 package com.kmpalette.palette.internal.utils
 
-import com.kmpalette.palette.internal.utils.ColorUtils
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.test.Test

--- a/androidx-palette/src/commonTest/kotlin/com/kmpalette/palette/internal/utils/PowKtTest.kt
+++ b/androidx-palette/src/commonTest/kotlin/com/kmpalette/palette/internal/utils/PowKtTest.kt
@@ -1,6 +1,5 @@
 package com.kmpalette.palette.internal.utils
 
-import com.kmpalette.palette.internal.utils.pow
 import kotlin.test.Test
 import kotlin.test.assertTrue
 

--- a/demo/composeApp/src/androidMain/kotlin/com/kmpalette/demo/App.android.kt
+++ b/demo/composeApp/src/androidMain/kotlin/com/kmpalette/demo/App.android.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
-import com.kmpalette.demo.App
 
 class AndroidApp : Application() {
 

--- a/extensions-base64/src/commonMain/kotlin/com/kmpalette/extensions/base64/Base64DominantColorState.kt
+++ b/extensions-base64/src/commonMain/kotlin/com/kmpalette/extensions/base64/Base64DominantColorState.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
  * @param[defaultOnColor] The default color to use _on_ [defaultColor].
  * @param[cacheSize] The size of the LruCache used to store recent results. Pass `0` to disable.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -30,7 +30,7 @@ public fun rememberBase64DominantColorState(
     defaultOnColor: Color,
     cacheSize: Int = DominantColorState.DEFAULT_CACHE_SIZE,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<String> = rememberDominantColorState(
     loader = Base64Loader,
@@ -38,6 +38,6 @@ public fun rememberBase64DominantColorState(
     defaultOnColor = defaultOnColor,
     cacheSize = cacheSize,
     coroutineContext = coroutineContext,
-    isColorValid = isColorValid,
+    isSwatchValid = isSwatchValid,
     builder = builder,
 )

--- a/extensions-base64/src/commonMain/kotlin/com/kmpalette/loader/Base64Loader.kt
+++ b/extensions-base64/src/commonMain/kotlin/com/kmpalette/loader/Base64Loader.kt
@@ -1,7 +1,6 @@
 package com.kmpalette.loader
 
 import androidx.compose.ui.graphics.ImageBitmap
-import com.kmpalette.loader.ByteArrayLoader
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 

--- a/extensions-bytearray/src/androidInstrumentedTest/kotlin/com/kmpalette/loader/AndroidByteArrayLoaderTest.kt
+++ b/extensions-bytearray/src/androidInstrumentedTest/kotlin/com/kmpalette/loader/AndroidByteArrayLoaderTest.kt
@@ -1,6 +1,5 @@
 package com.kmpalette.loader
 
-import com.kmpalette.loader.ByteArrayLoader
 import com.kmpalette.test.ImageBitmapUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/extensions-bytearray/src/appleTest/kotlin/com/kmpalette/loader/IosByteArrayLoaderTest.kt
+++ b/extensions-bytearray/src/appleTest/kotlin/com/kmpalette/loader/IosByteArrayLoaderTest.kt
@@ -1,6 +1,5 @@
 package com.kmpalette.loader
 
-import com.kmpalette.loader.ByteArrayLoader
 import com.kmpalette.test.ImageBitmapUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/extensions-bytearray/src/commonMain/kotlin/com/kmpalette/extensions/bytearray/ByteArrayDominantColorState.kt
+++ b/extensions-bytearray/src/commonMain/kotlin/com/kmpalette/extensions/bytearray/ByteArrayDominantColorState.kt
@@ -19,7 +19,7 @@ import kotlin.coroutines.CoroutineContext
  * @param[defaultOnColor] The default color to use _on_ [defaultColor].
  * @param[cacheSize] The size of the LruCache used to store recent results. Pass `0` to disable.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -31,7 +31,7 @@ public fun rememberByteArrayDominantColorState(
     defaultOnColor: Color,
     cacheSize: Int = DEFAULT_CACHE_SIZE,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<ByteArray> = rememberDominantColorState(
     loader = ByteArrayLoader,
@@ -39,6 +39,6 @@ public fun rememberByteArrayDominantColorState(
     defaultOnColor = defaultOnColor,
     cacheSize = cacheSize,
     coroutineContext = coroutineContext,
-    isColorValid = isColorValid,
+    isSwatchValid = isSwatchValid,
     builder = builder,
 )

--- a/extensions-libres/src/commonMain/kotlin/com/kmpalette/extensions/libres/LibresDominantColorState.kt
+++ b/extensions-libres/src/commonMain/kotlin/com/kmpalette/extensions/libres/LibresDominantColorState.kt
@@ -19,7 +19,7 @@ import kotlin.coroutines.CoroutineContext
  * @param[defaultOnColor] The default color to use _on_ [defaultColor].
  * @param[cacheSize] The size of the LruCache used to store recent results. Pass `0` to disable.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -31,7 +31,7 @@ public fun rememberLibresDominantColorState(
     defaultOnColor: Color,
     cacheSize: Int = DominantColorState.DEFAULT_CACHE_SIZE,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<Image> = rememberDominantColorState(
     loader = LibresLoader,
@@ -39,6 +39,6 @@ public fun rememberLibresDominantColorState(
     defaultOnColor = defaultOnColor,
     cacheSize = cacheSize,
     coroutineContext = coroutineContext,
-    isColorValid = isColorValid,
+    isSwatchValid = isSwatchValid,
     builder = builder,
 )

--- a/extensions-network/src/commonMain/kotlin/com/kmpalette/extensions/network/NetworkDominantColorState.kt
+++ b/extensions-network/src/commonMain/kotlin/com/kmpalette/extensions/network/NetworkDominantColorState.kt
@@ -25,7 +25,7 @@ import kotlin.coroutines.CoroutineContext
  * @param[httpClient] The [HttpClient] used to load the image.
  * @param[httpRequestBuilder] The [HttpRequestBuilder] used to load the image.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -39,7 +39,7 @@ public fun rememberNetworkDominantColorState(
     httpClient: HttpClient = HttpClient(),
     httpRequestBuilder: HttpRequestBuilder = HttpRequestBuilder(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<Url> = rememberDominantColorState(
     loader = NetworkLoader(httpClient, httpRequestBuilder),
@@ -47,6 +47,6 @@ public fun rememberNetworkDominantColorState(
     defaultOnColor = defaultOnColor,
     cacheSize = cacheSize,
     coroutineContext = coroutineContext,
-    isColorValid = isColorValid,
+    isSwatchValid = isSwatchValid,
     builder = builder,
 )

--- a/extensions-network/src/commonMain/kotlin/com/kmpalette/loader/NetworkImageBitmap.kt
+++ b/extensions-network/src/commonMain/kotlin/com/kmpalette/loader/NetworkImageBitmap.kt
@@ -1,7 +1,6 @@
 package com.kmpalette.loader
 
 import androidx.compose.ui.graphics.ImageBitmap
-import com.kmpalette.loader.ByteArrayLoader
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.request

--- a/extensions-resources/src/commonMain/kotlin/com/kmpalette/extensions.resources/ResourceDominantColorState.kt
+++ b/extensions-resources/src/commonMain/kotlin/com/kmpalette/extensions.resources/ResourceDominantColorState.kt
@@ -20,7 +20,7 @@ import kotlin.coroutines.CoroutineContext
  * @param[defaultOnColor] The default color to use _on_ [defaultColor].
  * @param[cacheSize] The size of the [LruCache] used to store recent results. Pass `0` to disable.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -33,7 +33,7 @@ public fun rememberResourcesDominantColorState(
     defaultOnColor: Color,
     cacheSize: Int = DominantColorState.DEFAULT_CACHE_SIZE,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<Resource> = rememberDominantColorState(
     loader = ResourceLoader,
@@ -41,6 +41,6 @@ public fun rememberResourcesDominantColorState(
     defaultOnColor = defaultOnColor,
     cacheSize = cacheSize,
     coroutineContext = coroutineContext,
-    isColorValid = isColorValid,
+    isSwatchValid = isSwatchValid,
     builder = builder,
 )

--- a/kmpalette-core/src/commonMain/kotlin/com/kmpalette/DominantColorState.kt
+++ b/kmpalette-core/src/commonMain/kotlin/com/kmpalette/DominantColorState.kt
@@ -37,7 +37,7 @@ private data class DominantColors(
  * @param[defaultOnColor] The default color to use _on_ [defaultColor].
  * @param[cacheSize] The size of the [LruCache] used to store recent results. Pass `0` to disable.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -49,7 +49,7 @@ public fun rememberDominantColorState(
     defaultOnColor: Color = MaterialTheme.colorScheme.onPrimary,
     cacheSize: Int = 0,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<ImageBitmap> = rememberDominantColorState(
     loader = ImageBitmapLoader,
@@ -57,7 +57,7 @@ public fun rememberDominantColorState(
     defaultOnColor = defaultOnColor,
     cacheSize = cacheSize,
     coroutineContext = coroutineContext,
-    isColorValid = isColorValid,
+    isSwatchValid = isSwatchValid,
     builder = builder,
 )
 
@@ -70,7 +70,7 @@ public fun rememberDominantColorState(
  * @param[defaultOnColor] The default color to use _on_ [defaultColor].
  * @param[cacheSize] The size of the [LruCache] used to store recent results. Pass `0` to disable.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ * @param[isSwatchValid] A lambda which allows filtering of the calculated [Palette.Swatch].
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette].
  * @return A [DominantColorState] which can be used to generate a dominant color
@@ -83,7 +83,7 @@ public fun <T : Any> rememberDominantColorState(
     defaultOnColor: Color = MaterialTheme.colorScheme.onPrimary,
     cacheSize: Int = DominantColorState.DEFAULT_CACHE_SIZE,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    isColorValid: (Color) -> Boolean = { true },
+    isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     builder: Palette.Builder.() -> Unit = {},
 ): DominantColorState<T> = remember(loader, defaultColor, defaultOnColor) {
     object : DominantColorState<T>(
@@ -91,7 +91,7 @@ public fun <T : Any> rememberDominantColorState(
         defaultOnColor = defaultOnColor,
         cacheSize = cacheSize,
         coroutineContext = coroutineContext,
-        isColorValid = isColorValid,
+        isSwatchValid = isSwatchValid,
         builder = builder,
     ) {
         override val loader: ImageBitmapLoader<T> = loader
@@ -110,7 +110,7 @@ public fun <T : Any> rememberDominantColorState(
  * @param[cacheSize] The size of the [LruCache] used to store recent results. Pass `0` to
  * disable the cache.
  * @param[coroutineContext] The [CoroutineContext] used to launch the coroutine.
- * @param[isColorValid] A lambda which allows filtering of the calculated image colors.
+ *
  * @param[builder] A lambda which allows customization of the [Palette.Builder] used to generate
  * the [Palette] from the input [T]
  */
@@ -121,7 +121,7 @@ public abstract class DominantColorState<T : Any>(
     private val defaultOnColor: Color,
     cacheSize: Int = DEFAULT_CACHE_SIZE,
     private val coroutineContext: CoroutineContext = Dispatchers.Default,
-    private val isColorValid: (Color) -> Boolean = { true },
+    private val isSwatchValid: (Palette.Swatch) -> Boolean = { true },
     private val builder: Palette.Builder.() -> Unit = {},
 ) {
 
@@ -174,7 +174,7 @@ public abstract class DominantColorState<T : Any>(
 
         return calculateSwatchesInImage(input, loader, builder)
             .sortedByDescending { swatch -> swatch.population }
-            .firstOrNull { swatch -> isColorValid(Color(swatch.rgb)) }
+            .firstOrNull { swatch -> isSwatchValid(swatch) }
             ?.let { swatch ->
                 DominantColors(
                     color = Color(swatch.rgb),

--- a/test-utils/src/androidMain/kotlin/com/kmpalette/test/ImageBitmapUtils.android.kt
+++ b/test-utils/src/androidMain/kotlin/com/kmpalette/test/ImageBitmapUtils.android.kt
@@ -3,7 +3,6 @@ package com.kmpalette.test
 import android.graphics.BitmapFactory
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import com.kmpalette.test.ImageBitmapUtils
 
 internal actual fun loadBitmap(): ImageBitmap {
     val bytes = ImageBitmapUtils.sampleBitmapBytes()

--- a/test-utils/src/jvmMain/kotlin/com/kmpalette/test/ImageBitmapUtils.jvm.kt
+++ b/test-utils/src/jvmMain/kotlin/com/kmpalette/test/ImageBitmapUtils.jvm.kt
@@ -2,7 +2,6 @@ package com.kmpalette.test
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
-import com.kmpalette.test.ImageBitmapUtils
 import org.jetbrains.skia.Bitmap
 
 internal actual fun loadBitmap(): ImageBitmap {

--- a/test-utils/src/nativeMain/kotlin/com/kmpalette/test/ImageBitmapUtils.native.kt
+++ b/test-utils/src/nativeMain/kotlin/com/kmpalette/test/ImageBitmapUtils.native.kt
@@ -2,7 +2,6 @@ package com.kmpalette.test
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
-import com.kmpalette.test.ImageBitmapUtils
 import org.jetbrains.skia.Bitmap
 
 internal actual fun loadBitmap(): ImageBitmap {


### PR DESCRIPTION
Resolves #14

Run "optimize imports" on the project.

BREAKING CHANGES:

- Change property name isColorValid -> isSwatchValid
- Filter lambda now exposes Palette.Swatch instead of a Color